### PR TITLE
Fix keyboard being cut off by Mobile Safari navigation bar

### DIFF
--- a/components/Keyboard.tsx
+++ b/components/Keyboard.tsx
@@ -45,7 +45,7 @@ const Keyboard: React.FC<KeyboardProps> = ({ keyStates, onKeyPress }) => {
   };
 
   return (
-    <div className="w-full max-w-sm mx-auto mb-4">
+    <div className="w-full max-w-sm mx-auto">
       <div className="flex flex-col space-y-2">
         {/* First row */}
         <div className="flex justify-center space-x-1.5">

--- a/components/Keyboard.tsx
+++ b/components/Keyboard.tsx
@@ -45,7 +45,7 @@ const Keyboard: React.FC<KeyboardProps> = ({ keyStates, onKeyPress }) => {
   };
 
   return (
-    <div className="w-full max-w-sm mx-auto">
+    <div className="w-full max-w-sm mx-auto mb-0">
       <div className="flex flex-col space-y-2">
         {/* First row */}
         <div className="flex justify-center space-x-1.5">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -233,13 +233,24 @@ export default function Home() {
           <h1 className="text-2xl sm:text-3xl font-bold text-center">Wordle Clone</h1>
         </header>
         
-        <main className="flex-1 w-full max-w-lg mx-auto px-3 sm:px-4 flex flex-col items-center justify-between pb-safe">
-          <div className="mt-2 sm:mt-4 mb-4">
+        <main className="flex-1 w-full max-w-lg mx-auto px-3 sm:px-4 flex flex-col items-center">
+          {/* Board is always at the top */}
+          <div className="mt-2 sm:mt-6 mb-4">
             <Board board={board} />
           </div>
-          <div className="mt-auto w-full pb-4 md:pb-0">
+          
+          {/* For mobile: Position keyboard at bottom of viewport with padding */}
+          <div className="sm:hidden fixed bottom-0 left-0 right-0 w-full bg-gray-100 dark:bg-gray-900 pt-2" style={{paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 28px)'}}>
             <Keyboard keyStates={keyStates} onKeyPress={handleKeyPress} />
           </div>
+          
+          {/* For desktop/tablet: Position keyboard directly below board with margin */}
+          <div className="hidden sm:block mt-8">
+            <Keyboard keyStates={keyStates} onKeyPress={handleKeyPress} />
+          </div>
+          
+          {/* Add spacer div for mobile to prevent content from being hidden behind keyboard */}
+          <div className="h-[230px] sm:hidden"></div>
         </main>
         
         {(gameStatus !== GameStatus.PLAYING || message) && (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -224,7 +224,7 @@ export default function Home() {
       <Head>
         <title>Wordle Clone</title>
         <meta name="description" content="A Wordle Clone game built with Next.js" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
         <link rel="apple-touch-icon" href="/wordle-favicon.svg" />
       </Head>
@@ -233,11 +233,11 @@ export default function Home() {
           <h1 className="text-2xl sm:text-3xl font-bold text-center">Wordle Clone</h1>
         </header>
         
-        <main className="flex-1 w-full max-w-lg mx-auto px-3 sm:px-4 flex flex-col items-center justify-between">
+        <main className="flex-1 w-full max-w-lg mx-auto px-3 sm:px-4 flex flex-col items-center justify-between pb-safe">
           <div className="mt-2 sm:mt-4 mb-4">
             <Board board={board} />
           </div>
-          <div className="mt-auto mb-3 sm:mb-4 w-full">
+          <div className="mt-auto w-full pb-4 md:pb-0">
             <Keyboard keyStates={keyStates} onKeyPress={handleKeyPress} />
           </div>
         </main>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,14 +1,24 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@import './safeareas.css';
+
+html {
+  height: -webkit-fill-available;
+}
 
 body {
   margin: 0;
+  min-height: 100vh;
+  /* mobile viewport bug fix */
+  min-height: -webkit-fill-available;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  /* Add constant bottom padding for mobile browsers */
+  padding-bottom: env(safe-area-inset-bottom, 0);
 }
 
 code {

--- a/styles/safeareas.css
+++ b/styles/safeareas.css
@@ -1,0 +1,23 @@
+/* iOS Safe Areas Utilities */
+.pb-safe {
+  padding-bottom: env(safe-area-inset-bottom, 2rem);
+}
+
+.pt-safe {
+  padding-top: env(safe-area-inset-top, 0);
+}
+
+.pl-safe {
+  padding-left: env(safe-area-inset-left, 0);
+}
+
+.pr-safe {
+  padding-right: env(safe-area-inset-right, 0);
+}
+
+/* Ensure content is always visible on iOS */
+@supports (padding: max(0px)) {
+  body {
+    padding-bottom: max(0.5rem, env(safe-area-inset-bottom, 0));
+  }
+}


### PR DESCRIPTION
- Add viewport-fit=cover to meta viewport
- Create safe area utilities for iOS devices
- Add padding to bottom of layout to account for Safari toolbar
- Update keyboard component to better fit in the available space
- Fix mobile viewport height issues